### PR TITLE
update to ncov-recombinant v0.7.0

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@ manifest {
 params {
   profile = false
   metadata = 'NO_FILE'
-  ncov_recombinant_version = '0.6.1'
+  ncov_recombinant_version = '0.7.0'
   completeness_threshold = 0.85
   split_by_plate = false
   artic_version = '1.3'


### PR DESCRIPTION
The ncov-recombinant pipeline was updated to v0.7.0 (https://github.com/ktmeaton/ncov-recombinant/releases/tag/v0.7.0)